### PR TITLE
Feature/ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ workflows:
       - test-calyx:
           requires:
             - build-calyx
-      - publish-calyx
+      - publish-calyx:
           requires:
             - test-calyx
           filters:
@@ -187,7 +187,7 @@ workflows:
               only:
                 - master
                 - dev
-      - publish-tagged-calyx
+      - publish-tagged-calyx:
           requires:
             - test-calyx
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.06.1-ce
+          # version: 18.06.1-ce
           docker_layer_caching: true
       - run:
           name: Build image
@@ -83,8 +83,8 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - setup_remote_docker:
-          version: 18.06.1-ce
+      - setup_remote_docker
+          # version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
@@ -95,8 +95,8 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - setup_remote_docker:
-          version: 18.06.1-ce
+      - setup_remote_docker
+          # version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
@@ -107,7 +107,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.06.1-ce
+          # version: 18.06.1-ce
           docker_layer_caching: true
       - restore_cache:
           keys:
@@ -144,8 +144,8 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - setup_remote_docker:
-          version: 18.06.1-ce
+      - setup_remote_docker
+          # version: 18.06.1-ce
       - run:
           name: Load previous image
           command: docker load -i /tmp/workspace/petals-cache.tar || true
@@ -157,8 +157,8 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - setup_remote_docker:
-          version: 18.06.1-ce
+      - setup_remote_docker
+          # version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/petals-image.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,12 @@ jobs:
   test-calyx:
     docker:
       - image: circleci/python:3.7
+        environment:
+          CALYX_SECRET_KEY: hogefugapiyopoyo
+          BULB_DB_USER: root
+          BULB_DB_PASSWORD: root
+          BULB_DB_NAME: saffron
+          BULB_DB_HOST: localhost
       - image: studioaquatan/mysql-utf8mb4:latest
         environment:
           MYSQL_ROOT_PASSWORD: root
@@ -65,11 +71,6 @@ jobs:
       - run:
           name: Run tests
           command: |
-            export CALYX_SECRET_KEY=hogefugapiyopoyo
-            export BULB_DB_USER=root
-            export BULB_DB_PASSWORD=root
-            export BULB_DB_NAME=saffron
-            export BULB_DB_HOST=localhost
             cd calyx/src && pipenv run python manage.py migrate
             cd calyx/src && pipenv run python manage.py test -v 2
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,213 @@
+version: 2.1
+executors:
+  calyx-executor:
+    environment:
+      IMAGE_NAME: studioaquatan/saffron-calyx
+    docker:
+      - image: circleci/python:3.7
+  petals-executor:
+    environment:
+      IMAGE_NAME: studioaquatan/saffron-petals
+    docker:
+      - image: circleci/node:11.1.0
+jobs:
+  build-calyx:
+    executor: calyx-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 18.09.0
+          docker_layer_caching: true
+      - run:
+          name: Build image
+          command: docker build ./calyx -t $IMAGE_NAME:latest
+      - run:
+          name: Archive docker image
+          command: docker save -o calyx-image.tar $IMAGE_NAME:latest
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./calyx-image.tar
+  test-calyx:
+    docker:
+      - image: circleci/python:3.7
+      - image: studioaquatan/mysql-utf8mb4:latest
+        environment:
+          MYSQL_ROOT_PASSWORD: 'root'
+          MYSQL_DATABASE: saffron
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker:
+          version: 18.09.0
+      - run:
+          name: Load archived image
+          command: docker load -i /tmp/workspace/calyx-image.tar
+      - run:
+          name: Wait for MySQL
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
+      - run:
+          name: Run tests
+          command: |
+            docker run --rm --net host -e CALYX_SECRET_KEY=hogefugapiyopoyo \
+              -e BULB_DB_USER=root -e BULB_DB_PASSWORD=root -e BULB_DB_NAME=saffron -e BULB_DB_HOST=localhost \
+              $IMAGE_NAME:latest python manage.py migrate
+            docker run --rm --net host -e CALYX_SECRET_KEY=hogefugapiyopoyo \
+              -e BULB_DB_USER=root -e BULB_DB_PASSWORD=root -e BULB_DB_NAME=saffron -e BULB_DB_HOST=localhost \
+              $IMAGE_NAME:latest python manage.py test -v 2
+  publish-calyx:
+    executor: calyx-executor
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker:
+          version: 18.09.0
+      - run:
+          name: Load archived image
+          command: docker load -i /tmp/workspace/calyx-image.tar
+      - run:
+          name: Login and push image
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_BRANCH
+            docker push $IMAGE_NAME:$CIRCLE_BRANCH
+  publish-tagged-calyx:
+    executor: calyx-executor
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker:
+          version: 18.09.0
+      - run:
+          name: Load archived image
+          command: docker load -i /tmp/workspace/calyx-image.tar
+      - run:
+          name: Login and push image
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_TAG
+            docker push $IMAGE_NAME:$CIRCLE_TAG
+  build-petals:
+    executor: petals-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 18.09.0
+          docker_layer_caching: true
+      - restore_cache:
+          keys:
+            - petals-cache-v1-{{ checksum "petals/yarn.lock" }}
+            - petals-cache-v1-
+            - petals-cache-
+      - run:
+          name: Load previous image
+          command: docker load -i petals-cache.tar || true
+      - run:
+          name: Build cache image
+          command: docker build ./petals --target develop -t $IMAGE_NAME:latest-cache
+      - run:
+          name: Archive cache image
+          command: docker save -o petals-cache.tar $IMAGE_NAME:latest-cache
+      - run:
+          name: Build production image
+          command: docker build ./petals --target production -t $IMAGE_NAME:latest
+      - run:
+          name: Archive docker image
+          command: docker save -o petals-image.tar $IMAGE_NAME:latest
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./petals-image.tar
+            - ./petals-cache.tar
+      - save_cache:
+          name: Save cache image
+          key: petals-cacche-v1-{{ checksum "petals/yarn.lock" }}
+          paths:
+            - ./petals-cache.tar
+  test-petals:
+    executor: petals-executor
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker:
+          version: 18.09.0
+          docker_layer_caching: true
+      - run:
+          name: Load previous image
+          command: docker load -i /tmp/workspace/petals-cache.tar || true
+      - run:
+          name: Test petals
+          command: docker run --rm $IMAGE_NAME:latest-cache yarn test
+  publish-petals:
+    executor: petals-executor
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker:
+          version: 18.09.0
+      - run:
+          name: Load archived image
+          command: docker load -i /tmp/workspace/petals-image.tar
+      - run:
+          name: Login and push image
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_BRANCH
+            docker push $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:$CIRCLE_BRANCH
+  publish-tagged-petals:
+    executor: petals-executor
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker:
+          version: 18.09.0
+      - run:
+          name: Load archived image
+          command: docker load -i /tmp/workspace/petals-image.tar
+      - run:
+          name: Login and push image
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_TAG
+            docker push $IMAGE_NAME:$CIRCLE_TAG
+workflows:
+  version: 2
+  build-master:
+    jobs:
+      - build-calyx
+      - test-calyx:
+          requires:
+            - build-calyx
+      - publish-calyx
+          requires:
+            - test-calyx
+          filters:
+            branches:
+              only:
+                - master
+                - dev
+      - publish-tagged-calyx
+          requires:
+            - test-calyx
+          filters:
+            tags:
+              only: /^v.*/
+      - build-petals
+      - test-petals:
+          requires:
+            - build-petals
+      - publish-petals:
+          requires:
+            - test-petals
+          filters:
+            branches:
+              only:
+                - master
+                - dev
+      - publish-tagged-petals:
+          requires:
+            - test-petals
+          filters:
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,9 @@ jobs:
       - run:
           name: Run tests
           command: |
-            cd calyx/src && pipenv run python manage.py migrate
-            cd calyx/src && pipenv run python manage.py test -v 2
+            cd calyx/src
+            pipenv run python manage.py migrate
+            pipenv run python manage.py test -v 2
       - save_cache:
           name: Save venv
           key: calyx-cache-v1-{{ checksum "calyx/src/Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.09.0
+          version: 18.09.0-ce
           docker_layer_caching: true
       - run:
           name: Build image
@@ -39,7 +39,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0
+          version: 18.09.0-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
@@ -61,7 +61,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0
+          version: 18.09.0-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
@@ -77,7 +77,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0
+          version: 18.09.0-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
@@ -92,7 +92,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.09.0
+          version: 18.09.0-ce
           docker_layer_caching: true
       - restore_cache:
           keys:
@@ -130,7 +130,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0
+          version: 18.09.0-ce
           docker_layer_caching: true
       - run:
           name: Load previous image
@@ -144,7 +144,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0
+          version: 18.09.0-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/petals-image.tar
@@ -161,7 +161,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0
+          version: 18.09.0-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/petals-image.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,18 @@
 version: 2.1
+commands:
+  docker_push:
+    description: "Push image to Docker hub with given tag "
+    parameters:
+      tag:
+        type: string
+        default: "latest"
+    steps:
+      - run:
+          name: Login and push image
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:<< parameters.tag >>
+            docker push $IMAGE_NAME:<< parameters.tag >>
 executors:
   calyx-executor:
     environment:
@@ -16,7 +30,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.09.0-ce
+          version: 18.06.1-ce
           docker_layer_caching: true
       - run:
           name: Build image
@@ -29,70 +43,71 @@ jobs:
           paths:
             - ./calyx-image.tar
   test-calyx:
+    working_directory: ~/calyx
     docker:
       - image: circleci/python:3.7
       - image: studioaquatan/mysql-utf8mb4:latest
         environment:
-          MYSQL_ROOT_PASSWORD: 'root'
+          MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: saffron
     steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - setup_remote_docker:
-          version: 18.09.0-ce
+      - checkout
+      - restore_cache:
+          keys:
+            - calyx-cache-v1-{{ checksum "calyx/src/Pipfile.lock" }}
+            - calyx-cache-v1-
+            - calyx-cache-
       - run:
-          name: Load archived image
-          command: docker load -i /tmp/workspace/calyx-image.tar
+          name: Pipenv sync
+          command: cd calyx/src && pipenv sync
       - run:
           name: Wait for MySQL
-          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
+          command: docker exec bulb dockerize -wait tcp://localhost:3306 -timeout 1m
       - run:
           name: Run tests
           command: |
-            docker run --rm --net host -e CALYX_SECRET_KEY=hogefugapiyopoyo \
-              -e BULB_DB_USER=root -e BULB_DB_PASSWORD=root -e BULB_DB_NAME=saffron -e BULB_DB_HOST=localhost \
-              $IMAGE_NAME:latest python manage.py migrate
-            docker run --rm --net host -e CALYX_SECRET_KEY=hogefugapiyopoyo \
-              -e BULB_DB_USER=root -e BULB_DB_PASSWORD=root -e BULB_DB_NAME=saffron -e BULB_DB_HOST=localhost \
-              $IMAGE_NAME:latest python manage.py test -v 2
+            export CALYX_SECRET_KEY=hogefugapiyopoyo
+            export BULB_DB_USER=root
+            export BULB_DB_PASSWORD=root
+            export BULB_DB_NAME=saffron
+            export BULB_DB_HOST=localhost
+            cd calyx/src && pipenv run python manage.py migrate
+            cd calyx/src && pipenv run python manage.py test -v 2
+      - save_cache:
+          name: Save venv
+          key: calyx-cache-v1-{{ checksum "calyx/src/Pipfile.lock" }}
+          paths:
+            - calyx/src/.venv
   publish-calyx:
     executor: calyx-executor
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0-ce
+          version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
-      - run:
-          name: Login and push image
-          command: |
-            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_BRANCH
-            docker push $IMAGE_NAME:$CIRCLE_BRANCH
+      - docker_push:
+          tag: $CIRCLE_BRANCH
   publish-tagged-calyx:
     executor: calyx-executor
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0-ce
+          version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
-      - run:
-          name: Login and push image
-          command: |
-            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_TAG
-            docker push $IMAGE_NAME:$CIRCLE_TAG
+      - docker_push:
+          tag: $CIRCLE_TAG
   build-petals:
     executor: petals-executor
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.09.0-ce
+          version: 18.06.1-ce
           docker_layer_caching: true
       - restore_cache:
           keys:
@@ -130,8 +145,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0-ce
-          docker_layer_caching: true
+          version: 18.06.1-ce
       - run:
           name: Load previous image
           command: docker load -i /tmp/workspace/petals-cache.tar || true
@@ -144,43 +158,33 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0-ce
+          version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/petals-image.tar
-      - run:
-          name: Login and push image
-          command: |
-            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_BRANCH
-            docker push $IMAGE_NAME:latest
-            docker push $IMAGE_NAME:$CIRCLE_BRANCH
+      - docker_push:
+          tag: $CIRCLE_BRANCH
   publish-tagged-petals:
     executor: petals-executor
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
-          version: 18.09.0-ce
+          version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/petals-image.tar
-      - run:
-          name: Login and push image
-          command: |
-            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_TAG
-            docker push $IMAGE_NAME:$CIRCLE_TAG
+      - docker_push:
+          tag: $CIRCLE_TAG
 workflows:
   version: 2
   build-master:
     jobs:
       - build-calyx
-      - test-calyx:
-          requires:
-            - build-calyx
+      - test-calyx
       - publish-calyx:
           requires:
+            - build-calyx
             - test-calyx
           filters:
             branches:
@@ -189,16 +193,18 @@ workflows:
                 - dev
       - publish-tagged-calyx:
           requires:
+            - build-calyx
             - test-calyx
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/
       - build-petals
-      - test-petals:
-          requires:
-            - build-petals
+      - test-petals
       - publish-petals:
           requires:
+            - build-petals
             - test-petals
           filters:
             branches:
@@ -207,7 +213,10 @@ workflows:
                 - dev
       - publish-tagged-petals:
           requires:
+            - build-petals
             - test-petals
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           command: cd calyx/src && pipenv sync
       - run:
           name: Wait for MySQL
-          command: docker exec bulb dockerize -wait tcp://localhost:3306 -timeout 1m
+          command: dockerize -wait tcp://localhost:3306 -timeout 1m
       - run:
           name: Run tests
           command: |
@@ -180,10 +180,11 @@ workflows:
   build-master:
     jobs:
       - build-calyx
-      - test-calyx
-      - publish-calyx:
+      - test-calyx:
           requires:
             - build-calyx
+      - publish-calyx:
+          requires:
             - test-calyx
           filters:
             branches:
@@ -200,10 +201,11 @@ workflows:
             branches:
               ignore: /.*/
       - build-petals
-      - test-petals
-      - publish-petals:
+      - test-petals:
           requires:
             - build-petals
+      - publish-petals:
+          requires:
             - test-petals
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
           paths:
             - ./calyx-image.tar
   test-calyx:
-    working_directory: ~/calyx
     docker:
       - image: circleci/python:3.7
       - image: studioaquatan/mysql-utf8mb4:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,15 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          # version: 18.06.1-ce
           docker_layer_caching: true
+      - restore_cache:
+          keys:
+            - calyx-image-cache-v1-{{ checksum "calyx/src/Pipfile.lock" }}
+            - calyx-image-cache-v1-
+            - calyx-image-cache-
+      - run:
+          name: Load archived image
+          command: docker load -i calyx-image.tar || true
       - run:
           name: Build image
           command: docker build ./calyx -t $IMAGE_NAME:latest
@@ -42,6 +49,11 @@ jobs:
           root: .
           paths:
             - ./calyx-image.tar
+      - save_cache:
+          name: Save image cache
+          key: calyx-image-cache-v1-{{ checksum "calyx/src/Pipfile.lock" }}
+          paths:
+            - ./calyx-image.tar
   test-calyx:
     docker:
       - image: circleci/python:3.7
@@ -50,7 +62,7 @@ jobs:
           BULB_DB_USER: root
           BULB_DB_PASSWORD: root
           BULB_DB_NAME: saffron
-          BULB_DB_HOST: localhost
+          BULB_DB_HOST: 127.0.0.1
       - image: studioaquatan/mysql-utf8mb4:latest
         environment:
           MYSQL_ROOT_PASSWORD: root
@@ -84,7 +96,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
-          # version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
@@ -96,7 +107,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
-          # version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/calyx-image.tar
@@ -107,7 +117,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          # version: 18.06.1-ce
           docker_layer_caching: true
       - restore_cache:
           keys:
@@ -116,7 +125,9 @@ jobs:
             - petals-cache-
       - run:
           name: Load previous image
-          command: docker load -i petals-cache.tar || true
+          command: |
+            docker load -i petals-cache.tar || true
+            docker load -i petals-image.tar || true
       - run:
           name: Build cache image
           command: docker build ./petals --target develop -t $IMAGE_NAME:latest-cache
@@ -136,8 +147,9 @@ jobs:
             - ./petals-cache.tar
       - save_cache:
           name: Save cache image
-          key: petals-cacche-v1-{{ checksum "petals/yarn.lock" }}
+          key: petals-cache-v1-{{ checksum "petals/yarn.lock" }}
           paths:
+            - ./petals-image.tar
             - ./petals-cache.tar
   test-petals:
     executor: petals-executor
@@ -145,7 +157,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
-          # version: 18.06.1-ce
       - run:
           name: Load previous image
           command: docker load -i /tmp/workspace/petals-cache.tar || true
@@ -158,7 +169,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
-          # version: 18.06.1-ce
       - run:
           name: Load archived image
           command: docker load -i /tmp/workspace/petals-image.tar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Saffron
+
+[![CircleCI](https://circleci.com/gh/StudioAquatan/Saffron.svg?style=svg)](https://circleci.com/gh/StudioAquatan/Saffron)
+
 研究室配属支援サービス
 
 2018年度中のリリースを予定

--- a/calyx/Dockerfile
+++ b/calyx/Dockerfile
@@ -8,8 +8,8 @@ RUN apk update && \
         pcre-dev && \
     rm -rf /var/cache/apk/*
 
-COPY src/Pipfile ${PROJECT_DIR}/
-COPY src/Pipfile.lock ${PROJECT_DIR}/
+COPY ./src/Pipfile ${PROJECT_DIR}/
+COPY ./src/Pipfile.lock ${PROJECT_DIR}/
 
 WORKDIR ${PROJECT_DIR}
 

--- a/calyx/src/.gitignore
+++ b/calyx/src/.gitignore
@@ -2,4 +2,3 @@
 .env
 .env.*
 !.env.sample
-Pipfile.lock

--- a/calyx/src/Pipfile.lock
+++ b/calyx/src/Pipfile.lock
@@ -1,0 +1,240 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "05db16156c8b467b0642f57f93a5521455f2cb1295bda8bb262ca49f7abc317c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "coreapi": {
+            "hashes": [
+                "sha256:46145fcc1f7017c076a2ef684969b641d18a2991051fddec9458ad3f78ffc1cb",
+                "sha256:bf39d118d6d3e171f10df9ede5666f63ad80bba9a29a8ec17726a66cf52ee6f3"
+            ],
+            "version": "==2.3.3"
+        },
+        "coreschema": {
+            "hashes": [
+                "sha256:5e6ef7bf38c1525d5e55a895934ab4273548629f16aed5c0a6caa74ebf45551f",
+                "sha256:9503506007d482ab0867ba14724b93c18a33b22b6d19fb419ef2d239dd4a1607"
+            ],
+            "version": "==0.0.4"
+        },
+        "django": {
+            "hashes": [
+                "sha256:068d51054083d06ceb32ce02b7203f1854256047a0d58682677dd4f81bceabd7",
+                "sha256:55409a056b27e6d1246f19ede41c6c610e4cab549c005b62cbeefabc6433356b"
+            ],
+            "index": "pypi",
+            "version": "==2.1.4"
+        },
+        "django-cors-headers": {
+            "hashes": [
+                "sha256:5545009c9b233ea7e70da7dbab7cb1c12afa01279895086f98ec243d7eab46fa",
+                "sha256:c4c2ee97139d18541a1be7d96fe337d1694623816d83f53cb7c00da9b94acae1"
+            ],
+            "index": "pypi",
+            "version": "==2.4.0"
+        },
+        "django-rest-swagger": {
+            "hashes": [
+                "sha256:48f6aded9937e90ae7cbe9e6c932b9744b8af80cc4e010088b3278c700e0685b",
+                "sha256:b039b0288bab4665cd45dc5d16f94b13911bc4ad0ed55f74ad3b90aa31c87c17"
+            ],
+            "index": "pypi",
+            "version": "==2.2.0"
+        },
+        "django-templated-mail": {
+            "hashes": [
+                "sha256:8db807effebb42a532622e2d142dfd453dafcd0d7794c4c3332acb90656315f9",
+                "sha256:f7127e1e31d7cad4e6c4b4801d25814d4b8782627ead76f4a75b3b7650687556"
+            ],
+            "version": "==1.1.1"
+        },
+        "djangorestframework": {
+            "hashes": [
+                "sha256:607865b0bb1598b153793892101d881466bd5a991de12bd6229abb18b1c86136",
+                "sha256:63f76cbe1e7d12b94c357d7e54401103b2e52aef0f7c1650d6c820ad708776e5"
+            ],
+            "index": "pypi",
+            "version": "==3.9.0"
+        },
+        "djangorestframework-jwt": {
+            "hashes": [
+                "sha256:5efe33032f3a4518a300dc51a51c92145ad95fb6f4b272e5aa24701db67936a7",
+                "sha256:ab15dfbbe535eede8e2e53adaf52ef0cf018ee27dbfad10cbc4cbec2ab63d38c"
+            ],
+            "index": "pypi",
+            "version": "==1.11.0"
+        },
+        "djoser": {
+            "hashes": [
+                "sha256:1537948cd6aa271ce3d67413ea69e2cd6a585205294c8cb6053d8fefcbfa39d3",
+                "sha256:243448346f521073c0a9d61ad9541055b8ba271b73fa1c62ea2d6d699738e370"
+            ],
+            "index": "pypi",
+            "version": "==1.3.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "itypes": {
+            "hashes": [
+                "sha256:c6e77bb9fd68a4bfeb9d958fea421802282451a25bac4913ec94db82a899c073"
+            ],
+            "version": "==1.1.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
+                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+            ],
+            "version": "==2.10"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
+                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
+                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
+                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
+                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
+                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
+                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
+                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
+                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
+                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
+                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
+                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
+                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
+                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
+                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
+                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
+                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
+                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
+                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
+                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
+                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
+                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
+                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
+                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
+                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
+                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
+                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
+                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
+            ],
+            "version": "==1.1.0"
+        },
+        "mysqlclient": {
+            "hashes": [
+                "sha256:062d78953acb23066c0387a8f3bd0ecf946626f599145bb7fd201460e8f773e1",
+                "sha256:3981ae9ce545901a36a8b7aed76ed02960a429f75dc53b7ad77fb2f9ab7cd56b",
+                "sha256:b3591a00c0366de71d65108627899710d9cfb00e575c4d211aa8de59b1f130c9"
+            ],
+            "index": "pypi",
+            "version": "==1.3.14"
+        },
+        "openapi-codec": {
+            "hashes": [
+                "sha256:1bce63289edf53c601ea3683120641407ff6b708803b8954c8a876fe778d2145"
+            ],
+            "version": "==1.3.2"
+        },
+        "pyjwt": {
+            "hashes": [
+                "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
+                "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"
+            ],
+            "version": "==1.7.1"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:a84569d0e00d178bc5b957f7ff208bf49287cbf61857c31c258c4a91f571527b",
+                "sha256:c9b1ddd3cdbe75c7d462cb84674d87130f4b948f090f02c7d7144779afb99ae0"
+            ],
+            "index": "pypi",
+            "version": "==0.10.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+            ],
+            "version": "==2018.7"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "version": "==2.21.0"
+        },
+        "simplejson": {
+            "hashes": [
+                "sha256:067a7177ddfa32e1483ba5169ebea1bc2ea27f224853211ca669325648ca5642",
+                "sha256:2fc546e6af49fb45b93bbe878dea4c48edc34083729c0abd09981fe55bdf7f91",
+                "sha256:354fa32b02885e6dae925f1b5bbf842c333c1e11ea5453ddd67309dc31fdb40a",
+                "sha256:37e685986cf6f8144607f90340cff72d36acf654f3653a6c47b84c5c38d00df7",
+                "sha256:3af610ee72efbe644e19d5eaad575c73fb83026192114e5f6719f4901097fce2",
+                "sha256:3b919fc9cf508f13b929a9b274c40786036b31ad28657819b3b9ba44ba651f50",
+                "sha256:3dd289368bbd064974d9a5961101f080e939cbe051e6689a193c99fb6e9ac89b",
+                "sha256:6c3258ffff58712818a233b9737fe4be943d306c40cf63d14ddc82ba563f483a",
+                "sha256:75e3f0b12c28945c08f54350d91e624f8dd580ab74fd4f1bbea54bc6b0165610",
+                "sha256:b1f329139ba647a9548aa05fb95d046b4a677643070dc2afc05fa2e975d09ca5",
+                "sha256:ee9625fc8ee164902dfbb0ff932b26df112da9f871c32f0f9c1bcf20c350fe2a",
+                "sha256:fb2530b53c28f0d4d84990e945c2ebb470edb469d63e389bf02ff409012fe7c5"
+            ],
+            "version": "==3.16.0"
+        },
+        "uritemplate": {
+            "hashes": [
+                "sha256:01c69f4fe8ed503b2951bef85d996a9d22434d2431584b5b107b2981ff416fbd",
+                "sha256:1b9c467a940ce9fb9f50df819e8ddd14696f89b9a8cc87ac77952ba416e0a8fd",
+                "sha256:c02643cebe23fc8adb5e6becffe201185bf06c40bda5c0b4028a93f1527d011d"
+            ],
+            "version": "==3.0.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        },
+        "uwsgi": {
+            "hashes": [
+                "sha256:d2318235c74665a60021a4fc7770e9c2756f9fc07de7b8c22805efe85b5ab277"
+            ],
+            "index": "pypi",
+            "version": "==2.0.17.1"
+        }
+    },
+    "develop": {}
+}


### PR DESCRIPTION
fix #26 

- ビルド
- テスト
- （タグ有りまたはdevかmasterブランチなら）Docker hubへPush

という構成になってる．まだその段階ではないと思ったのと，ちょっとデプロイ方法に悩んでいるのでデプロイセクションは今回は無しにしてある．

テスト方法が少し変な構成になっていて，Petalsは単体でテストが完結するのでmuilti stage buildの途中の段階で一旦止めたimageから`yarn test`を発行するスタイル，CalyxはMySQLを必要とすることからCircle CIのpython image内で`pipenv sync`して`manage.py test`するという方式になってる．

devかmasterにマージするとこの後にImageをPushするフローが追加される．

<img width="992" alt="2018-12-31 11 49 33" src="https://user-images.githubusercontent.com/14105201/50553817-2aba9280-0cf2-11e9-9231-9d74e64b06c8.png">

