### PR TITLE
Feature/join api

### DIFF
--- a/calyx/src/Pipfile
+++ b/calyx/src/Pipfile
@@ -13,6 +13,7 @@ python-dotenv = "*"
 uwsgi = "*"
 mysqlclient = "*"
 django-cors-headers = "*"
+drf-nested-routers = "*"
 
 [dev-packages]
 

--- a/calyx/src/Pipfile.lock
+++ b/calyx/src/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "05db16156c8b467b0642f57f93a5521455f2cb1295bda8bb262ca49f7abc317c"
+            "sha256": "dc351860712c746b88c032bfe68e4f7dfa5ce5adc9f1353f7666f66d307d5949"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,11 +46,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:068d51054083d06ceb32ce02b7203f1854256047a0d58682677dd4f81bceabd7",
-                "sha256:55409a056b27e6d1246f19ede41c6c610e4cab549c005b62cbeefabc6433356b"
+                "sha256:a32c22af23634e1d11425574dce756098e015a165be02e4690179889b207c7a8",
+                "sha256:d6393918da830530a9516bbbcbf7f1214c3d733738779f06b0f649f49cc698c3"
             ],
             "index": "pypi",
-            "version": "==2.1.4"
+            "version": "==2.1.5"
         },
         "django-cors-headers": {
             "hashes": [
@@ -98,6 +98,14 @@
             ],
             "index": "pypi",
             "version": "==1.3.2"
+        },
+        "drf-nested-routers": {
+            "hashes": [
+                "sha256:46e5c3abc15c782cafafd7d75028e8f9121bbc6228e3599bbb48a3daa4585034",
+                "sha256:60c1e1f5cc801e757d26a8138e61c44419ef800c213c3640c5b6138e77d46762"
+            ],
+            "index": "pypi",
+            "version": "==0.91"
         },
         "idna": {
             "hashes": [

--- a/calyx/src/courses/permissions.py
+++ b/calyx/src/courses/permissions.py
@@ -1,7 +1,7 @@
 from rest_framework import permissions
 
 
-class IsAdmin(permissions.IsAdminUser):
+class IsAdmin(permissions.BasePermission):
     """
     スーパーユーザならばTrue
     """
@@ -15,9 +15,6 @@ class IsCourseMember(permissions.BasePermission):
     課程に所属するメンバーならばTrue
     """
 
-    def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated
-
     def has_object_permission(self, request, view, obj):
         user = request.user
         if obj.users.filter(pk=user.pk).exists():
@@ -29,9 +26,6 @@ class IsCourseAdmin(permissions.BasePermission):
     """
     課程の管理グループに所属するメンバーならばTrue
     """
-
-    def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated
 
     def has_object_permission(self, request, view, obj):
         user = request.user

--- a/calyx/src/courses/serializers.py
+++ b/calyx/src/courses/serializers.py
@@ -108,3 +108,13 @@ class YearSerializer(serializers.ModelSerializer):
         fields = ("pk", "year", "courses")
 
 
+class PINCodeSerializer(serializers.Serializer):
+    """
+    PINコードを取得する
+    """
+
+    class Meta:
+        fields = ("pin_code",)
+
+    def to_internal_value(self, data):
+        return {'pin_code': data['pin_code']}

--- a/calyx/src/courses/serializers.py
+++ b/calyx/src/courses/serializers.py
@@ -113,6 +113,8 @@ class PINCodeSerializer(serializers.Serializer):
     PINコードを取得する
     """
 
+    pin_code = serializers.CharField(required=True, write_only=True)
+
     class Meta:
         fields = ("pin_code",)
 

--- a/calyx/src/courses/tests/base.py
+++ b/calyx/src/courses/tests/base.py
@@ -54,3 +54,6 @@ class JWTAuthMixin(object):
         payload = jwt_payload_handler(user)
         token = jwt_encode_handler(payload)
         self.client.credentials(HTTP_AUTHORIZATION="JWT " + token)
+
+    def _unset_credentials(self):
+        self.client.credentials(HTTP_AUTHORIZATION="")

--- a/calyx/src/courses/tests/base.py
+++ b/calyx/src/courses/tests/base.py
@@ -1,6 +1,7 @@
 import json
 from copy import deepcopy
 from collections import OrderedDict
+from rest_framework_jwt.settings import api_settings
 
 
 years = [2017, 2018, 2019]
@@ -41,3 +42,15 @@ class DatasetMixin(object):
     def to_dict(self, data: OrderedDict) -> dict:
         """OrderedDictを標準のdictに変換する"""
         return json.loads(json.dumps(data, ensure_ascii=False))
+
+
+class JWTAuthMixin(object):
+
+    def _set_credentials(self, user=None):
+        if not user:
+            user = self.user
+        jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
+        jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
+        payload = jwt_payload_handler(user)
+        token = jwt_encode_handler(payload)
+        self.client.credentials(HTTP_AUTHORIZATION="JWT " + token)

--- a/calyx/src/courses/tests/test_views.py
+++ b/calyx/src/courses/tests/test_views.py
@@ -1,22 +1,12 @@
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
-from rest_framework_jwt.settings import api_settings
 from courses.models import Course
-from .base import DatasetMixin
+from .base import DatasetMixin, JWTAuthMixin
 
 User = get_user_model()
 
 
-class CourseViewSetsTest(DatasetMixin, APITestCase):
-
-    def _set_credentials(self, user=None):
-        if not user:
-            user = self.user
-        jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
-        jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
-        payload = jwt_payload_handler(user)
-        token = jwt_encode_handler(payload)
-        self.client.credentials(HTTP_AUTHORIZATION="JWT " + token)
+class CourseViewSetsTest(DatasetMixin, JWTAuthMixin, APITestCase):
 
     def setUp(self):
         super(CourseViewSetsTest, self).setUp()
@@ -122,16 +112,7 @@ class CourseViewSetsTest(DatasetMixin, APITestCase):
         self.assertEqual(expected_json, self.to_dict(resp.data))
 
 
-class YearViewSetsTest(DatasetMixin, APITestCase):
-
-    def _set_credentials(self, user=None):
-        if not user:
-            user = self.user
-        jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
-        jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
-        payload = jwt_payload_handler(user)
-        token = jwt_encode_handler(payload)
-        self.client.credentials(HTTP_AUTHORIZATION="JWT " + token)
+class YearViewSetsTest(DatasetMixin, JWTAuthMixin, APITestCase):
 
     def setUp(self):
         super(YearViewSetsTest, self).setUp()
@@ -163,3 +144,47 @@ class YearViewSetsTest(DatasetMixin, APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="")
         resp = self.client.get('/years/', format='json')
         self.assertEqual(401, resp.status_code)
+
+
+class JoinViewTest(DatasetMixin, JWTAuthMixin, APITestCase):
+
+    def setUp(self):
+        super(JoinViewTest, self).setUp()
+        self.user = User.objects.create_user(**self.user_data_set[0], is_active=True)
+        self._set_credentials()
+
+    def test_join(self):
+        """POST /courses/<pk>/join/"""
+        course_data = self.course_data_set[0]
+        course = Course.objects.create_course(**course_data)
+        payload = {'pin_code': course_data['pin_code']}
+        resp = self.client.post(f'/courses/{course.pk}/join/', data=payload, format='json')
+        expected = {
+            'pk': course.pk,
+            'name': course.name,
+            'year': course.year.year,
+            'users': [
+                {
+                    "pk": self.user.pk,
+                    "username": self.user.username,
+                    "is_admin": False
+                }
+            ]
+        }
+        self.assertEqual(201, resp.status_code)
+        self.assertEqual(expected, self.to_dict(resp.data))
+        # 同じユーザの二度目の加入はエラー
+        resp = self.client.post(f'/courses/{course.pk}/join/', data=payload, format='json')
+        self.assertEqual(400, resp.status_code)
+
+    def test_join_with_invalid_pin_code(self):
+        """POST /couses/<pk>/join/"""
+        course_data = self.course_data_set[0]
+        course = Course.objects.create_course(**course_data)
+        # 間違ったPINコードで参加
+        payload = {'pin_code': 'invalid_code'}
+        resp = self.client.post(f'/courses/{course.pk}/join/', data=payload, format='json')
+        self.assertEqual(400, resp.status_code)
+        # 存在しない課程に対してジョイン
+        resp = self.client.post('/courses/9999/join/', data=payload, format='json')
+        self.assertEqual(404, resp.status_code)

--- a/calyx/src/courses/tests/test_views.py
+++ b/calyx/src/courses/tests/test_views.py
@@ -61,6 +61,11 @@ class CourseViewSetsTest(DatasetMixin, JWTAuthMixin, APITestCase):
         """GET /course/<pk>/"""
         course_data = self.course_data_set[0]
         course = Course.objects.create_course(**course_data)
+        # ログインしていなければ詳細を閲覧できない
+        self._unset_credentials()
+        resp = self.client.get(f'/courses/{course.pk}/', data={}, format='json')
+        self.assertEqual(401, resp.status_code)
+        self._set_credentials()
         # 参加していないユーザは詳細を閲覧できない
         resp = self.client.get(f'/courses/{course.pk}/', data={}, format='json')
         self.assertEqual(403, resp.status_code)
@@ -188,3 +193,13 @@ class JoinViewTest(DatasetMixin, JWTAuthMixin, APITestCase):
         # 存在しない課程に対してジョイン
         resp = self.client.post('/courses/9999/join/', data=payload, format='json')
         self.assertEqual(404, resp.status_code)
+
+    def test_join_permission(self):
+        """POST /courses/<pk>/join/"""
+        course_data = self.course_data_set[0]
+        course = Course.objects.create_course(**course_data)
+        payload = {'pin_code': course_data['pin_code']}
+        # ログインしていなければ参加できない
+        self._unset_credentials()
+        resp = self.client.post(f'/courses/{course.pk}/join/', data=payload, format='json')
+        self.assertEqual(401, resp.status_code)

--- a/calyx/src/courses/urls.py
+++ b/calyx/src/courses/urls.py
@@ -1,13 +1,18 @@
 from django.urls import path, include
 from rest_framework import routers
-from .views import CourseViewSet, YearViewSet
+from rest_framework_nested.routers import NestedDefaultRouter
+from .views import CourseViewSet, YearViewSet, JoinAPIView
 
 router = routers.DefaultRouter()
 
 router.register('courses', CourseViewSet, basename='course')
 router.register('years', YearViewSet, basename='year')
 
+course_nested_router = NestedDefaultRouter(router, r'courses', lookup='course')
+course_nested_router.register('join', JoinAPIView, basename='join')
+
 app_name = 'course'
 urlpatterns = [
-    path('', include(router.urls))
+    path('', include(router.urls)),
+    path('', include(course_nested_router.urls)),
 ]

--- a/calyx/src/courses/urls.py
+++ b/calyx/src/courses/urls.py
@@ -13,6 +13,6 @@ course_nested_router.register('join', JoinAPIView, basename='join')
 
 app_name = 'course'
 urlpatterns = [
-    path('', include(router.urls)),
-    path('', include(course_nested_router.urls)),
+    path('', include(router.get_urls())),
+    path('', include(course_nested_router.get_urls())),
 ]

--- a/calyx/src/courses/views.py
+++ b/calyx/src/courses/views.py
@@ -1,10 +1,12 @@
 from django.db import transaction
 from django.db.models import Prefetch
 from django.contrib.auth import get_user_model
-from rest_framework import viewsets, permissions, mixins
+from rest_framework import viewsets, permissions, mixins, serializers, status, exceptions
+from rest_framework.response import Response
 from .models import Course, Year
-from .serializers import CourseSerializer, CourseWithoutUserSerializer, YearSerializer
+from .serializers import CourseSerializer, CourseWithoutUserSerializer, YearSerializer, PINCodeSerializer
 from .permissions import IsAdmin, IsCourseMember, IsCourseAdmin
+from .errors import AlreadyJoinedError
 
 User = get_user_model()
 
@@ -63,3 +65,47 @@ class YearViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     queryset = Year.objects.prefetch_related('courses').all()
     serializer_class = YearSerializer
     permission_classes = [permissions.IsAuthenticated]
+
+
+class JoinAPIView(mixins.CreateModelMixin, viewsets.GenericViewSet):
+    """
+    課程に参加するAPIビュー
+
+    create:
+        課程に参加する
+    """
+    queryset = Course.objects.prefetch_related(
+        Prefetch('users', User.objects.prefetch_related('groups', 'courses').all()),
+    ).select_related('admin_user_group', 'year').all()
+    serializer_class = CourseSerializer
+    permission_classes = [IsCourseMember | IsAdmin]
+
+    def create(self, request, course_pk=None, *args, **kwargs):
+        """
+        POSTされたら送ったユーザを課程に参加させる
+        :param request: リクエストオブジェクト
+        :param course_pk: Course APIにネストされているため，そのプライマリキーを取得できる
+        :param args:
+        :param kwargs:
+        :return:
+        """
+        if not isinstance(course_pk, int):
+            course_pk = int(course_pk)
+        try:
+            course = self.get_queryset().get(pk=course_pk)
+        except Course.DoesNotExist:
+            raise exceptions.NotFound({'non_field_errors': 'この課程は存在しません．'})
+        # PINコードをパース
+        pin_code_serializer = PINCodeSerializer(data=request.data)
+        pin_code_serializer.is_valid(raise_exception=True)
+        pin_code = pin_code_serializer.validated_data['pin_code']
+        try:
+            # 参加に成功すればTrue，失敗すればFalse
+            joined = course.join(request.user, pin_code)
+            if not joined:
+                raise serializers.ValidationError({'pin_code': 'PINコードが正しくありません．'})
+        except AlreadyJoinedError:
+            raise serializers.ValidationError({'non_field_errors': 'このユーザは既に参加しています．'})
+        course_serializer = CourseSerializer(course)
+        headers = self.get_success_headers(course_serializer.data)
+        return Response(course_serializer.data, status=status.HTTP_201_CREATED, headers=headers)


### PR DESCRIPTION
fix #68 

- POST `/courses/{pk}/join/`
```json
{
  "pin_code": "PINコード"
}
```

レスポンスは正常時はGET `/courses/{pk}/`と同じ．PINコードが正しくないときは

```json
{
  "pin_code": "PINコードが正しくありません．
}
```

また，

- 存在しないプライマリキーを指定すると404が返る
- 加入済みユーザで行うと400が返る
```json
{
  "non_field_errors": "このユーザは既に参加しています．"
}
```