### PR TITLE
Feature/make admin api

### DIFF
--- a/calyx/src/courses/schemas.py
+++ b/calyx/src/courses/schemas.py
@@ -1,0 +1,35 @@
+import coreapi
+import coreschema
+from rest_framework import schemas
+
+
+course_pk_field = coreapi.Field(
+    "course_pk",
+    required=True,
+    location="path",
+    schema=coreschema.Integer(description="対象とする課程のプライマリキー")
+)
+
+
+class CourseAdminSchema(schemas.AutoSchema):
+
+    def get_manual_fields(self, path, method):
+        manual_fields = super(CourseAdminSchema, self).get_manual_fields(path, method)
+        extras = [course_pk_field]
+        if method in ["PUT", "PATCH"]:
+            extras += [
+                coreapi.Field(
+                   "id",
+                    required=True,
+                    location="path",
+                    schema=coreschema.Integer(description="対象となる所属メンバーのプライマリキー")
+                )
+            ]
+        return manual_fields + extras
+
+
+class CourseJoinSchema(schemas.AutoSchema):
+
+    def get_manual_fields(self, path, method):
+        manual_fields = super(CourseJoinSchema, self).get_manual_fields(path, method)
+        return manual_fields + [course_pk_field]

--- a/calyx/src/courses/serializers.py
+++ b/calyx/src/courses/serializers.py
@@ -129,3 +129,25 @@ class PINCodeSerializer(serializers.Serializer):
 
     def to_internal_value(self, data):
         return {'pin_code': data['pin_code']}
+
+
+class UserSerializer(serializers.ModelSerializer):
+    """
+    ユーザオブジェクトのシリアライザ
+    """
+
+    # NestedViewMixinで使用される親要素のフィルタリング．
+    # dirty hackっぽいが，Course一覧からプライマリキーでフィルタをかけて1つに絞り，参加するユーザ一覧を取得する
+    # `course_pk`がURLパラメータのキー，`pk`が絞り込みに使用するキー
+    parent_lookup_kwargs = {
+        'course_pk': 'pk'
+    }
+
+    class Meta:
+        model = User
+        fields = ("pk", "username", "email", "screen_name")
+        extra_kwargs = {
+            "username": {"read_only": True},
+            "email": {"read_only": True},
+            "screen_name": {"read_only": True},
+        }

--- a/calyx/src/courses/tests/test_views.py
+++ b/calyx/src/courses/tests/test_views.py
@@ -177,7 +177,8 @@ class JoinViewTest(DatasetMixin, JWTAuthMixin, APITestCase):
                     "username": self.user.username,
                     "is_admin": False
                 }
-            ]
+            ],
+            'is_admin': False
         }
         self.assertEqual(201, resp.status_code)
         self.assertEqual(expected, self.to_dict(resp.data))

--- a/calyx/src/courses/urls.py
+++ b/calyx/src/courses/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 from rest_framework import routers
 from rest_framework_nested.routers import NestedDefaultRouter
-from .views import CourseViewSet, YearViewSet, JoinAPIView
+from .views import CourseViewSet, YearViewSet, JoinAPIView, CourseAdminView
 
 router = routers.DefaultRouter()
 
@@ -10,6 +10,7 @@ router.register('years', YearViewSet, basename='year')
 
 course_nested_router = NestedDefaultRouter(router, r'courses', lookup='course')
 course_nested_router.register('join', JoinAPIView, basename='join')
+course_nested_router.register('admins', CourseAdminView, basename='admin')
 
 app_name = 'course'
 urlpatterns = [

--- a/calyx/src/courses/views.py
+++ b/calyx/src/courses/views.py
@@ -10,6 +10,7 @@ from .serializers import (
 )
 from .permissions import IsAdmin, IsCourseMember, IsCourseAdmin
 from .errors import AlreadyJoinedError, NotJoinedError
+from .schemas import CourseJoinSchema, CourseAdminSchema
 
 User = get_user_model()
 
@@ -82,6 +83,7 @@ class JoinAPIView(mixins.CreateModelMixin, viewsets.GenericViewSet):
     ).select_related('admin_user_group', 'year').all()
     serializer_class = PINCodeSerializer
     permission_classes = [permissions.IsAuthenticated]
+    schema = CourseJoinSchema()
 
     def create(self, request, course_pk=None, *args, **kwargs):
         if not isinstance(course_pk, int):
@@ -122,6 +124,7 @@ class CourseAdminView(NestedViewSetMixin, mixins.UpdateModelMixin, mixins.ListMo
     ).select_related('admin_user_group', 'year').all()
     serializer_class = UserSerializer
     permission_classes = [(IsCourseMember & IsCourseAdmin) | IsAdmin]
+    schema = CourseAdminSchema()
 
     def partial_update(self, request, *args, **kwargs):
         return super(CourseAdminView, self).partial_update(request, *args, **kwargs)

--- a/calyx/src/courses/views.py
+++ b/calyx/src/courses/views.py
@@ -147,7 +147,7 @@ class CourseAdminView(NestedViewSetMixin, mixins.UpdateModelMixin, mixins.ListMo
                 raise serializers.ValidationError({'non_field_errors': 'このユーザは既に管理者として登録されています．'})
             course.register_as_admin(user)
         except NotJoinedError:
-            raise serializers.ValidationError({'pk': 'このユーザはこの課程のメンバーではありません'})
+            raise serializers.ValidationError({'non_field_errors': 'このユーザはこの課程のメンバーではありません'})
         serializer = self.get_serializer(user)
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/calyx/src/courses/views.py
+++ b/calyx/src/courses/views.py
@@ -3,10 +3,13 @@ from django.db.models import Prefetch
 from django.contrib.auth import get_user_model
 from rest_framework import viewsets, permissions, mixins, serializers, status, exceptions
 from rest_framework.response import Response
+from rest_framework_nested.viewsets import NestedViewSetMixin
 from .models import Course, Year
-from .serializers import CourseSerializer, CourseWithoutUserSerializer, YearSerializer, PINCodeSerializer
+from .serializers import (
+    CourseSerializer, CourseWithoutUserSerializer, YearSerializer, PINCodeSerializer, UserSerializer
+)
 from .permissions import IsAdmin, IsCourseMember, IsCourseAdmin
-from .errors import AlreadyJoinedError
+from .errors import AlreadyJoinedError, NotJoinedError
 
 User = get_user_model()
 
@@ -86,7 +89,7 @@ class JoinAPIView(mixins.CreateModelMixin, viewsets.GenericViewSet):
         try:
             course = self.get_queryset().get(pk=course_pk)
         except Course.DoesNotExist:
-            raise exceptions.NotFound({'non_field_errors': 'この課程は存在しません．'})
+            raise exceptions.NotFound('この課程は存在しません．')
         # PINコードをパース
         pin_code_serializer = self.get_serializer(data=request.data)
         pin_code_serializer.is_valid(raise_exception=True)
@@ -101,3 +104,50 @@ class JoinAPIView(mixins.CreateModelMixin, viewsets.GenericViewSet):
         course_serializer = CourseSerializer(course, context=self.get_serializer_context())
         headers = self.get_success_headers(course_serializer.data)
         return Response(course_serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+class CourseAdminView(NestedViewSetMixin, mixins.UpdateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
+    """
+    各課程の管理者に関するView
+    update:
+        IDを指定して管理者でないユーザを管理者に昇格する
+    partial_update:
+        IDを指定して管理者でないユーザを管理者に昇格する
+    list:
+        管理者一覧を表示する
+    """
+
+    queryset = Course.objects.prefetch_related(
+        Prefetch('users', User.objects.prefetch_related('groups', 'courses').all()),
+    ).select_related('admin_user_group', 'year').all()
+    serializer_class = UserSerializer
+    permission_classes = [(IsCourseMember & IsCourseAdmin) | IsAdmin]
+
+    def partial_update(self, request, *args, **kwargs):
+        return super(CourseAdminView, self).partial_update(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        pk = kwargs.pop('pk')
+        course = self.get_queryset().first()
+        if course is None:
+            raise exceptions.NotFound('この課程は存在しません．')
+        try:
+            user = course.users.get(pk=pk)
+        except User.DoesNotExist:
+            raise exceptions.NotFound('指定されたユーザはこの課程に参加していないか，存在しません．')
+        try:
+            if user.groups.filter(name=course.admin_group_name).exists():
+                raise serializers.ValidationError({'non_field_errors': 'このユーザは既に管理者として登録されています．'})
+            course.register_as_admin(user)
+        except NotJoinedError:
+            raise serializers.ValidationError({'pk': 'このユーザはこの課程のメンバーではありません'})
+        serializer = self.get_serializer(user)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def list(self, request, *args, **kwargs):
+        course = self.get_queryset().first()
+        if course is None:
+            raise exceptions.NotFound('この課程は存在しません．')
+        admins = course.users.filter(groups__name=course.admin_group_name).all()
+        serializer = self.get_serializer(admins, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
fix #69 

ユーザを課程の管理者に昇格する

- GET `/courses/{course_pk}/admins/`
  - メンバーのみ閲覧可能
  - その課程の管理者全員のリストを返す
```json
[
  {
    "pk": 1,
    "username": "ユーザ名",
    "email": "ユーザ名@edu.kit.ac.jp",
    "screen_name": "表示名"
  }
]
```
- PUT/PATCH `/courses/{course_pk}/admins/{user_pk}/`
  - その課程の管理者のみ操作可能
  - ユーザのプライマリキーを指定して管理者に昇格
  - PUT/PATCHの際のボディは特に必要ない
```json
{
  "pk": 1,
  "username": "ユーザ名",
  "email": "ユーザ名@edu.kit.ac.jp",
  "screen_name": "表示名"
}
```
  - 既に管理者の場合400
```
{
  "non_field_errors": "このユーザは既に管理者として登録されています．"
}
```
  - その課程に所属していないメンバーに対して実行すると400
```
{
  "non_field_errors": "このユーザはこの課程のメンバーではありません"
}
```