### PR TITLE
Add `is_admin` attr to detail response

### DIFF
--- a/calyx/src/courses/serializers.py
+++ b/calyx/src/courses/serializers.py
@@ -23,10 +23,11 @@ class CourseSerializer(serializers.ModelSerializer):
 
     users = serializers.SerializerMethodField(read_only=True)
     year = serializers.IntegerField(source='year.year')
+    is_admin = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Course
-        fields = ("pk", "name", "users", "pin_code", "year")
+        fields = ("pk", "name", "users", "pin_code", "year", "is_admin")
         extra_kwargs = {
             'pin_code': {'write_only': True}
         }
@@ -76,6 +77,14 @@ class CourseSerializer(serializers.ModelSerializer):
                 'is_admin': user.groups.filter(name=group_name).exists()
             } for user in users
         ]
+
+    def get_is_admin(self, obj):
+        try:
+            user = self.context['request'].user
+        except KeyError:
+            return False
+        group_name = obj.admin_group_name
+        return user.groups.filter(name=group_name).exists()
 
 
 class CourseWithoutUserSerializer(serializers.ModelSerializer):

--- a/calyx/src/courses/tests/test_serializers.py
+++ b/calyx/src/courses/tests/test_serializers.py
@@ -76,7 +76,8 @@ class CourseSerializerTest(DatasetMixin, TestCase):
             'pk': course.pk,
             'name': course.name,
             'year': course.year.year,
-            'users': []
+            'users': [],
+            'is_admin': False
         }
         self.assertEqual(expected_json, serializer.data)
 
@@ -97,7 +98,8 @@ class CourseSerializerTest(DatasetMixin, TestCase):
                     'username': user.username,
                     'is_admin': False
                 }
-            ]
+            ],
+            'is_admin': False
         }
         self.assertEqual(expected_json, serializer.data)
 

--- a/calyx/src/courses/tests/test_views.py
+++ b/calyx/src/courses/tests/test_views.py
@@ -52,7 +52,8 @@ class CourseViewSetsTest(DatasetMixin, APITestCase):
                     "username": self.user.username,
                     "is_admin": True
                 }
-            ]
+            ],
+            'is_admin': True
         }
         self.assertEqual(201, resp.status_code)
         actual = self.to_dict(resp.data)
@@ -87,7 +88,8 @@ class CourseViewSetsTest(DatasetMixin, APITestCase):
                     'username': self.user.username,
                     'is_admin': False
                 }
-            ]
+            ],
+            'is_admin': False
         }
         self.assertEqual(200, resp.status_code)
         self.assertEqual(expected_json, self.to_dict(resp.data))
@@ -116,7 +118,8 @@ class CourseViewSetsTest(DatasetMixin, APITestCase):
                     'username': self.user.username,
                     'is_admin': True
                 }
-            ]
+            ],
+            'is_admin': True
         }
         self.assertEqual(200, resp.status_code)
         self.assertEqual(expected_json, self.to_dict(resp.data))


### PR DESCRIPTION
fix #75 

```json
 {
  "pk": 1,
  "name": "ユーザ名",
  "year": 2018,
  "users": [
    {
      "pk": 1,
      "username": "ユーザ名",
      "is_admin": false
    }
  ],
  "is_admin": false
}
```