### PR TITLE
Calyx/config cache

### DIFF
--- a/calyx/src/calyx/settings.py
+++ b/calyx/src/calyx/settings.py
@@ -87,6 +87,14 @@ DATABASES = {
     }
 }
 
+# TODO: 本番環境ではRedisかMemcachedにした方が良い
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'unique-snowflake',
+    }
+}
+
 DEFAULT_FROM_EMAIL = os.getenv('CALYX_EMAIL_DEFAULT_FROM', 'example@example.com')
 EMAIL_ENABLED = os.getenv('CALYX_EMAIL_ENABLED', 'False').lower() == 'true'
 

--- a/calyx/src/courses/models.py
+++ b/calyx/src/courses/models.py
@@ -2,6 +2,7 @@ import unicodedata
 
 from typing import TYPE_CHECKING
 from django.contrib.auth.models import Group
+from django.core.cache import cache
 from django.db import models, transaction, IntegrityError
 from django.contrib.auth.hashers import make_password, check_password
 from django.contrib.auth import get_user_model
@@ -283,3 +284,17 @@ def move_up_ranks(sender, instance: 'Lab', **kwargs):
         # 最後の志望の研究室はNULLにする
         rank_to_del.lab = None
         rank_to_del.save()
+
+
+@receiver(models.signals.post_save, sender=Config)
+def set_config_cache(sender, instance: 'Config', **kwargs):
+    """
+    設定が更新されたときにキャッシュも更新する
+    :param sender: Modelクラス
+    :param instance: 設定のインスタンス
+    :param kwargs:
+    :return:
+    """
+    config_dict = instance.__dict__
+    cache_key = f"course-config-{instance.course_id}"
+    cache.set(cache_key, config_dict)

--- a/calyx/src/courses/models.py
+++ b/calyx/src/courses/models.py
@@ -297,7 +297,8 @@ def set_config_cache(sender, instance: 'Config', **kwargs):
     """
     config_dict = {
         'show_gpa': instance.show_gpa,
-        'show_username': instance.show_username
+        'show_username': instance.show_username,
+        'rank_limit': instance.rank_limit,
     }
     cache_key = f"course-config-{instance.course_id}"
     cache.set(cache_key, config_dict)

--- a/calyx/src/courses/models.py
+++ b/calyx/src/courses/models.py
@@ -295,6 +295,9 @@ def set_config_cache(sender, instance: 'Config', **kwargs):
     :param kwargs:
     :return:
     """
-    config_dict = instance.__dict__
+    config_dict = {
+        'show_gpa': instance.show_gpa,
+        'show_username': instance.show_username
+    }
     cache_key = f"course-config-{instance.course_id}"
     cache.set(cache_key, config_dict)

--- a/calyx/src/courses/permissions.py
+++ b/calyx/src/courses/permissions.py
@@ -40,20 +40,47 @@ class IsCourseAdmin(permissions.IsAuthenticated):
         return False
 
 
-class SatisfyCourseRequirements(permissions.IsAuthenticated):
-    """
-    課程の設定項目を満たしていればTrue
-    """
-    def has_object_permission(self, request, view, obj: 'Course'):
-        user = request.user
-        config = cache.get(f'course-config-{obj.pk}')
-        return (
-                self.satisfy_requirements(config['show_username'], user.screen_name) &
-                self.satisfy_requirements(config['show_gpa'], user.gpa)
-        )
+class GPARequirement(permissions.IsAuthenticated):
+    """GPAを入力しているかどうか．表示設定がFalseなら常にTrueが返る"""
+
+    message = "GPAが未入力です．"
 
     def satisfy_requirements(self, show: bool, obj: 'Optional[str, float]') -> bool:
         if show:
             if obj is None:
                 return False
+        return True
+
+    def get_config(self, obj):
+        return cache.get(f'course-config-{obj.pk}')
+
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        config = self.get_config(obj)
+        return self.satisfy_requirements(config['show_gpa'], user.gpa)
+
+
+class ScreenNameRequirement(GPARequirement):
+    """screen_nameを入力しているかどうか．表示設定がFalseなら常にTrueが返る"""
+
+    message = "表示名が未入力です．"
+
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        config = self.get_config(obj)
+        return self.satisfy_requirements(config['show_username'], user.screen_name)
+
+
+class RankSubmitted(GPARequirement):
+    """志望を提出しているかどうか"""
+
+    message = "研究室の志望順位がまだ提出されていない，または規定の数を満たしていません．"
+
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        config = self.get_config(obj)
+        rank_limit = config['rank_limit']
+        user_submitted = user.rank_set.filter(course=obj).count()
+        if rank_limit != user_submitted:
+            return False
         return True

--- a/calyx/src/courses/permissions.py
+++ b/calyx/src/courses/permissions.py
@@ -1,7 +1,9 @@
 from typing import TYPE_CHECKING
+from django.core.cache import cache
 from rest_framework import permissions
 
 if TYPE_CHECKING:
+    from typing import Optional
     from .models import Course
 
 
@@ -36,3 +38,22 @@ class IsCourseAdmin(permissions.IsAuthenticated):
         if user.groups.filter(name=obj.admin_group_name).exists():
             return True
         return False
+
+
+class SatisfyCourseRequirements(permissions.IsAuthenticated):
+    """
+    課程の設定項目を満たしていればTrue
+    """
+    def has_object_permission(self, request, view, obj: 'Course'):
+        user = request.user
+        config = cache.get(f'course-config-{obj.pk}')
+        return (
+                self.satisfy_requirements(config['show_username'], user.screen_name) &
+                self.satisfy_requirements(config['show_gpa'], user.gpa)
+        )
+
+    def satisfy_requirements(self, show: bool, obj: 'Optional[str, float]') -> bool:
+        if show:
+            if obj is None:
+                return False
+        return True

--- a/calyx/src/courses/tests/base.py
+++ b/calyx/src/courses/tests/base.py
@@ -1,7 +1,14 @@
 import json
 from copy import deepcopy
 from collections import OrderedDict
+from typing import TYPE_CHECKING
 from rest_framework_jwt.settings import api_settings
+
+from courses.models import Lab, Rank
+
+if TYPE_CHECKING:
+    from courses.models import Course
+    from typing import List, Dict
 
 
 years = [2017, 2018, 2019]
@@ -67,6 +74,19 @@ class DatasetMixin(object):
     def to_dict(self, data: OrderedDict) -> dict:
         """OrderedDictを標準のdictに変換する"""
         return json.loads(json.dumps(data, ensure_ascii=False))
+
+    def create_labs(self, course: 'Course') -> 'List[Lab]':
+        return [Lab.objects.create(**lab_data, course=course) for lab_data in self.lab_data_set]
+
+    def submit_ranks(self, labs: "List[Lab]", user) -> 'List[Rank]':
+        ranks = []
+        for i, lab in enumerate(labs):
+            rank = Rank.objects.create(lab=lab, course=lab.course, user=user, order=i)
+            ranks.append(rank)
+        return ranks
+
+    def create_rank_order(self, labs: 'List[Lab]') -> 'List[Dict[str, int]]':
+        return [{'lab': lab.pk for lab in labs}]
 
 
 class JWTAuthMixin(object):

--- a/calyx/src/courses/tests/views/test_ranks_view.py
+++ b/calyx/src/courses/tests/views/test_ranks_view.py
@@ -26,7 +26,7 @@ class RankViewTest(DatasetMixin, JWTAuthMixin, APITestCase):
         self.assertEqual(expected, self.to_dict(resp.data))
         ranks = Rank.objects.filter(course=self.course, user=self.user).all()
         for i, lab in enumerate(self.labs):
-            self.assertTrue(ranks.filter(lab=lab, order=i+1).exists())
+            self.assertTrue(ranks.filter(lab=lab, order=i).exists())
         # 数が少ない
         resp = self.client.post(f'/courses/{self.course.pk}/ranks/', data=expected[1:], format='json')
         self.assertEqual(400, resp.status_code)
@@ -61,7 +61,7 @@ class RankViewTest(DatasetMixin, JWTAuthMixin, APITestCase):
         self.assertEqual([], self.to_dict(resp.data))
         ranks = [
             Rank.objects.create(
-                course=self.course, user=self.user, lab=lab, order=i+1
+                course=self.course, user=self.user, lab=lab, order=i
             ) for i, lab in enumerate(self.labs)
         ]
         expected = [
@@ -75,7 +75,6 @@ class RankViewTest(DatasetMixin, JWTAuthMixin, APITestCase):
             "pk": self.user.pk,
             "username": self.user.username,
             "email": self.user.email,
-            "screen_name": self.user.screen_name
         }
         for i in range(len(ranks)):
             expected[i]['rank_set'] = [[], [], []]

--- a/calyx/src/courses/tests/views/test_ranks_view.py
+++ b/calyx/src/courses/tests/views/test_ranks_view.py
@@ -41,6 +41,19 @@ class RankViewTest(DatasetMixin, JWTAuthMixin, APITestCase):
         resp = self.client.post(f'/courses/9999/ranks/', data=expected, format='json')
         self.assertEqual(404, resp.status_code)
 
+    def test_update_rank(self):
+        """POST /courses/<course_pk>/ranks/"""
+        self.course.join(self.user, self.pin_code)
+        self.submit_ranks(self.labs, self.user)
+        # 逆順にして更新する
+        expected = [{'lab': lab.pk} for lab in self.labs][::-1]
+        resp = self.client.post(f'/courses/{self.course.pk}/ranks/', data=expected, format='json')
+        self.assertEqual(201, resp.status_code)
+        self.assertEqual(expected, self.to_dict(resp.data))
+        ranks = Rank.objects.filter(course=self.course, user=self.user).all()
+        for i, lab in enumerate(self.labs[::-1]):
+            self.assertTrue(ranks.filter(lab=lab, order=i).exists())
+
     def test_create_rank_permission(self):
         """POST /courses/<course_pk>/ranks/"""
         expected = [{'lab': lab.pk} for lab in self.labs]

--- a/calyx/src/courses/views.py
+++ b/calyx/src/courses/views.py
@@ -9,7 +9,7 @@ from .serializers import (
     CourseSerializer, CourseWithoutUserSerializer, YearSerializer, PINCodeSerializer,
     UserSerializer, ConfigSerializer, LabSerializer, RankSerializer, LabAbstractSerializer
 )
-from .permissions import IsAdmin, IsCourseMember, IsCourseAdmin
+from .permissions import IsAdmin, IsCourseMember, IsCourseAdmin, SatisfyCourseRequirements
 from .errors import AlreadyJoinedError, NotJoinedError, NotAdminError
 from .schemas import CourseJoinSchema, CourseAdminSchema, LabSchema
 
@@ -43,7 +43,7 @@ class CourseViewSet(viewsets.ModelViewSet):
         if self.action == 'list' or self.action == 'create':
             self.permission_classes = [permissions.IsAuthenticated]
         elif self.action == 'retrieve':
-            self.permission_classes = [IsCourseMember | IsAdmin]
+            self.permission_classes = [(IsCourseMember | IsAdmin) & SatisfyCourseRequirements]
         else:
             self.permission_classes = [(IsCourseMember & IsCourseAdmin) | IsAdmin]
         return super(CourseViewSet, self).get_permissions()

--- a/calyx/src/courses/views.py
+++ b/calyx/src/courses/views.py
@@ -9,7 +9,9 @@ from .serializers import (
     CourseSerializer, CourseWithoutUserSerializer, YearSerializer, PINCodeSerializer,
     UserSerializer, ConfigSerializer, LabSerializer, RankSerializer, LabAbstractSerializer
 )
-from .permissions import IsAdmin, IsCourseMember, IsCourseAdmin, SatisfyCourseRequirements
+from .permissions import (
+    IsAdmin, IsCourseMember, IsCourseAdmin, GPARequirement, ScreenNameRequirement, RankSubmitted
+)
 from .errors import AlreadyJoinedError, NotJoinedError, NotAdminError
 from .schemas import CourseJoinSchema, CourseAdminSchema, LabSchema
 
@@ -43,7 +45,7 @@ class CourseViewSet(viewsets.ModelViewSet):
         if self.action == 'list' or self.action == 'create':
             self.permission_classes = [permissions.IsAuthenticated]
         elif self.action == 'retrieve':
-            self.permission_classes = [(IsCourseMember | IsAdmin) & SatisfyCourseRequirements]
+            self.permission_classes = [(IsCourseMember | IsAdmin) & GPARequirement & ScreenNameRequirement]
         else:
             self.permission_classes = [(IsCourseMember & IsCourseAdmin) | IsAdmin]
         return super(CourseViewSet, self).get_permissions()
@@ -249,8 +251,11 @@ class LabViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         return LabSerializer
 
     def get_permissions(self):
-        if self.action == "list" or self.action == "retrieve":
+        if self.action == "list":
             self.permission_classes = [IsCourseMember | IsAdmin]
+        elif self.action == "retrieve":
+            self.permission_classes = [(IsCourseMember | IsAdmin) & GPARequirement &
+                                       ScreenNameRequirement & RankSubmitted]
         else:
             self.permission_classes = [(IsCourseMember & IsCourseAdmin) | IsAdmin]
         return super(LabViewSet, self).get_permissions()

--- a/petals/.gitignore
+++ b/petals/.gitignore
@@ -8,6 +8,8 @@
 
 # production
 /build
+/dist
+/.cache
 
 # misc
 .DS_Store


### PR DESCRIPTION
fix #118 

以下の内容を検証するパーミッションを実装

-`courses.permissions.GPARequirement`
  - GPAのチェック
- `courses.permissions.ScreenNameRequirement`
  - 表示名のチェック
- `courses.permissions.RankSubmitted`
  - 希望提出数のチェック

それぞれ以下のエンドポイントに適用されている

- GET `/courses/<course_pk>/
  - `GPARequirement`, `ScreenNameRequirement`
  - ユーザの情報が表示されるので希望提出数を除いたパーミッションを検証する
- GET `/courses/<course_pk>/labs/<lab_pk>/`
  - `GPARequirement`, `ScreenNameRequirement`, `RankSubmitted`

#129 に関連してPOST `/courses/<course_pk>/ranks/`にもパーミッションをかけるか検討している．