### PR TITLE
Feature/makefile refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,11 @@ guard-env-%:
 
 # Manage frontend application container and database container only for backend development.
 build-client-%: guard-env-%
-	@docker-compose -f docker-compose.${*}.yml build petals
+	@if [ "${*}" == "dev" ]; then \
+		docker-compose -f docker-compose.${*}.yml build petals; \
+	else \
+		make petals-image; \
+	fi
 
 start-client-%: guard-env-%
 	@echo "Run frontend application container (Petals)"
@@ -82,8 +86,7 @@ migrate-client-%: migrate-%
 manage-client-%: manage-%
 
 # Manage backend application container and database container only for frontend development.
-build-api-%: guard-env-%
-	@docker-compose -f docker-compose.${*}.yml build calyx
+build-api-%: guard-env-% calyx-image
 
 start-api-%: guard-env-%
 	@echo "Run backend application container (Calyx)"

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ restart-client-%: guard-env-%
 	@docker-compose -f docker-compose.${*}.yml restart petals bulb
 
 # Shortcut for update backends
-update-client-%: guard-env-% petals-image start-client-% prune
+update-client-%: guard-env-% build-client-% start-client-% prune
 	@echo "Petals container is now up-to-date."
 
 # To keep compatibility

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ clean-client-%: clean-%
 restart-client-%: guard-env-%
 	@docker-compose -f docker-compose.${*}.yml restart petals bulb
 
+# Shortcut for update backends
+update-client-%: guard-env-% petals-image start-client-% prune
+	@echo "Petals container is now up-to-date."
+
 # To keep compatibility
 migrate-client-%: migrate-%
 manage-client-%: manage-%
@@ -92,6 +96,10 @@ clean-api-%: clean-%
 
 restart-api-%: guard-env-%
 	@docker-compose -f docker-compose.${*}.yml restart calyx bulb
+
+# Shortcut for update backends
+update-api-%: guard-env-% calyx-image start-api-% migrate-% prune
+	@echo "Calyx container is now up-to-date."
 
 # To keep compatibility
 migrate-api-%: migrate-%
@@ -147,4 +155,4 @@ env-%: $(API_SRC_DIR)/src/.env.% $(DB_DIR)/.env.%
 
 env: env-qa env-dev env-prod
 
-.PHONY: venv image pull db deps dev dev-clean dev-stop guard-env-% start-% stop-% clean-% manage-% migrate-% prune env-% env ;
+.PHONY: venv image pull db deps dev dev-clean dev-stop guard-env-% start-% stop-% clean-% manage-% migrate-% prune env-% env update-% ;


### PR DESCRIPTION
## 変更点

- ソースファイルの変更を検知してyarn buildの可否を決めるのを辞めた
    - 現状`make build`する機会がほとんどない
- Petals開発用にCalyxとDBだけ起動するモードを追加
    - `make start-api-dev`: コンテナの起動
    - `make stop-api-dev`: コンテナの停止
    - `make clean-api-dev`: コンテナの停止と削除
    - `make restart-api-dev`: コンテナの再起動
- Calyx開発用にPetalsとDBだけ起動するモードを追加
    - `make start-client-dev`: コンテナの起動
    - `make stop-client-dev`: コンテナの停止
    - `make clean-client-dev`: コンテナの停止と削除
    - `make restart-client-dev`: コンテナの再起動
- コンテナをアップグレードするためのショートカットの追加
    - `make update-api-dev`: Calyxのimageを再ビルド，コンテナを再構築して起動，マイグレーションを実行，dangling image削除
    - `make update-client-dev`: 上記のPetals版（マイグレーションはない）
- テストコマンドの追加
    - `make test-petals`: `yarn test`する
    - `make test-calyx`: `pipenv run python manage.py test`する
    - `make test`: 上記をどちらも実行する