### PR TITLE
他課程の研究室が表示されるバグの修正

### DIFF
--- a/calyx/src/courses/views/courses.py
+++ b/calyx/src/courses/views/courses.py
@@ -4,7 +4,6 @@ from django.db.models import Prefetch
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, permissions, mixins, exceptions
 from rest_framework.response import Response
-from rest_framework_nested.viewsets import NestedViewSetMixin
 
 from courses.models import Course, Year, Config
 from courses.permissions import (
@@ -14,6 +13,7 @@ from courses.schemas import CourseJoinSchema
 from courses.serializers import (
     CourseSerializer, CourseWithoutUserSerializer, YearSerializer, ConfigSerializer
 )
+from .mixins import NestedViewSetMixin
 
 User = get_user_model()
 

--- a/calyx/src/courses/views/labs.py
+++ b/calyx/src/courses/views/labs.py
@@ -2,7 +2,6 @@ from django.contrib.auth import get_user_model
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, status, exceptions
 from rest_framework.response import Response
-from rest_framework_nested.viewsets import NestedViewSetMixin
 
 from courses.models import Course, Lab
 from courses.permissions import (
@@ -12,6 +11,7 @@ from courses.schemas import LabSchema
 from courses.serializers import (
     LabSerializer, LabAbstractSerializer
 )
+from .mixins import NestedViewSetMixin
 
 User = get_user_model()
 

--- a/calyx/src/courses/views/mixins.py
+++ b/calyx/src/courses/views/mixins.py
@@ -1,0 +1,11 @@
+class NestedViewSetMixin(object):
+
+    def get_queryset(self):
+        queryset = super(NestedViewSetMixin, self).get_queryset()
+        serializer_class = self.get_serializer_class()
+        if hasattr(serializer_class, 'parent_lookup_kwargs'):
+            orm_filters = {}
+            for query_param, field_name in serializer_class.parent_lookup_kwargs.items():
+                orm_filters[field_name] = self.kwargs[query_param]
+            return queryset.filter(**orm_filters)
+        return queryset

--- a/calyx/src/courses/views/ranks.py
+++ b/calyx/src/courses/views/ranks.py
@@ -2,7 +2,6 @@ from django.contrib.auth import get_user_model
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, mixins, status, exceptions
 from rest_framework.response import Response
-from rest_framework_nested.viewsets import NestedViewSetMixin
 
 from courses.models import Course, Rank
 from courses.permissions import (
@@ -11,6 +10,7 @@ from courses.permissions import (
 from courses.serializers import (
     LabSerializer, RankSerializer
 )
+from .mixins import NestedViewSetMixin
 
 User = get_user_model()
 


### PR DESCRIPTION
drf-nested-routersのNestedViewSetMixinが`self.get_serializer_class()`を使用せずに`self.serializer_class`を直接参照しているため，動的なシリアライザの変更に対応できていないことが問題．

パッチする気はあるが，受け入れられるかは不明なので手元で修正．