### PR TITLE
課程のエンドポイントを刷新

### DIFF
--- a/calyx/src/courses/serializers/__init__.py
+++ b/calyx/src/courses/serializers/__init__.py
@@ -1,4 +1,12 @@
-from .course import ConfigSerializer, CourseSerializer, CourseWithoutUserSerializer, PINCodeSerializer, YearSerializer
+from .course import (
+    ConfigSerializer,
+    ReadOnlyCourseSerializer,
+    CourseCreateSerializer,
+    CourseUpdateSerializer,
+    CourseWithoutUserSerializer,
+    PINCodeSerializer,
+    YearSerializer
+)
 from .lab import LabAbstractSerializer, LabListCreateSerializer, LabSerializer
 from .rank import (
     RankSerializer,

--- a/calyx/src/courses/serializers/__init__.py
+++ b/calyx/src/courses/serializers/__init__.py
@@ -16,4 +16,4 @@ from .rank import (
     RankSummaryPerLabSerializer
 )
 from .user import UserSerializer
-from .course_user import CourseStatusSerializer, CourseStatusDetailSerializer
+from .course_user import CourseStatusSerializer, CourseStatusDetailSerializer, JoinSerializer

--- a/calyx/src/courses/serializers/__init__.py
+++ b/calyx/src/courses/serializers/__init__.py
@@ -5,6 +5,7 @@ from .course import (
     CourseUpdateSerializer,
     CourseWithoutUserSerializer,
     PINCodeSerializer,
+    PINCodeUpdateSerializer,
     YearSerializer
 )
 from .lab import LabAbstractSerializer, LabListCreateSerializer, LabSerializer

--- a/calyx/src/courses/serializers/course.py
+++ b/calyx/src/courses/serializers/course.py
@@ -22,7 +22,7 @@ def validate_pin_code(pin_code: str):
     try:
         password_validation.validate_password(pin_code, password_validators=get_pin_code_validators())
     except exceptions.ValidationError as e:
-        raise serializers.ValidationError(str(e))
+        raise serializers.ValidationError(''.join(e))
     return pin_code
 
 

--- a/calyx/src/courses/serializers/course.py
+++ b/calyx/src/courses/serializers/course.py
@@ -32,64 +32,19 @@ class ConfigSerializer(serializers.ModelSerializer):
         fields = ("show_gpa", "show_username", "rank_limit")
 
 
-class CourseSerializer(serializers.ModelSerializer):
+class ReadOnlyCourseSerializer(serializers.ModelSerializer):
     """
-    課程のシリアライザ．年度はリレーション先から年度の数字のみを取得して返す．
+    課程をJsonにシリアライズするのみのシリアライザ．年度はリレーション先から年度の数字のみを取得して返す．
     所属するユーザはそのプライマリキーと学生IDのみを返す．
     """
-
     users = serializers.SerializerMethodField(read_only=True)
-    year = serializers.IntegerField(source='year.year')
+    year = serializers.IntegerField(source='year.year', read_only=True)
+    config = ConfigSerializer(read_only=True)
     is_admin = serializers.SerializerMethodField(read_only=True)
-    config = ConfigSerializer(required=False)
 
     class Meta:
         model = Course
-        fields = ("pk", "name", "users", "pin_code", "year", "is_admin", "config")
-        extra_kwargs = {
-            'pin_code': {'write_only': True}
-        }
-
-    def create(self, validated_data):
-        # yearは{'year': {'year': 20xx}}という辞書になっている
-        validated_data['year'] = validated_data['year']['year']
-        try:
-            course = Course.objects.create_course(**validated_data)
-            if 'request' in self.context.keys():
-                course.join(self.context['request'].user, validated_data['pin_code'])
-            return course
-        except IntegrityError:
-            raise serializers.ValidationError({'name': f'{validated_data["name"]}は既に存在しています．'})
-
-    def update(self, instance, validated_data):
-        try:
-            pin_code = validated_data.pop('pin_code')
-            instance.set_password(pin_code)
-        except KeyError:
-            pass
-        # yearは{'year': {'year': 20xx}}という辞書になっている
-        year = validated_data.get('year', instance.year.year)
-        if isinstance(year, dict):
-            year = year.get('year')
-        validated_data['year'], _ = Year.objects.get_or_create(year=year)
-        # configはOrderedDict
-        config = validated_data.get('config', instance.config)
-        if not isinstance(config, Config):
-            config, _ = Config.objects.update_or_create(course=instance, defaults=config)
-        validated_data['config'] = config
-
-        for key, val in validated_data.items():
-            setattr(instance, key, val)
-        validated_data.pop('config')
-        instance.save(update_fields=validated_data.keys())
-        return instance
-
-    def validate_pin_code(self, data):
-        try:
-            password_validation.validate_password(data, password_validators=get_pin_code_validators())
-        except exceptions.ValidationError as e:
-            raise serializers.ValidationError(str(e))
-        return data
+        fields = ("pk", "name", "users", "year", "config", "is_admin")
 
     @swagger_serializer_method(serializer_or_field=UserSerializer(many=True))
     def get_users(self, obj):
@@ -110,6 +65,67 @@ class CourseSerializer(serializers.ModelSerializer):
             return False
         group_name = obj.admin_group_name
         return user.groups.filter(name=group_name).exists()
+
+
+class CourseCreateSerializer(serializers.ModelSerializer):
+    """
+    課程を作成するためのシリアライザ
+    """
+
+    year = serializers.IntegerField()
+    config = ConfigSerializer(required=False)
+
+    class Meta:
+        model = Course
+        fields = ("pk", "name", "pin_code", "year", "config")
+        extra_kwargs = {
+            'pin_code': {'write_only': True}
+        }
+
+    def validate_pin_code(self, data):
+        try:
+            password_validation.validate_password(data, password_validators=get_pin_code_validators())
+        except exceptions.ValidationError as e:
+            raise serializers.ValidationError(str(e))
+        return data
+
+    def create(self, validated_data):
+        try:
+            course = Course.objects.create_course(**validated_data)
+            if 'request' in self.context.keys():
+                course.join(self.context['request'].user, validated_data['pin_code'])
+            return course
+        except IntegrityError:
+            raise serializers.ValidationError({'name': f'{validated_data["name"]}は既に存在しています．'})
+
+
+class CourseUpdateSerializer(serializers.ModelSerializer):
+    """
+    課程の情報を更新するためのシリアライザ．年度，PINコードの変更は出来ない．
+    """
+    config = ConfigSerializer(required=False)
+
+    class Meta:
+        model = Course
+        fields = ("pk", "name", "config")
+
+    def update(self, instance, validated_data):
+        try:
+            pin_code = validated_data.pop('pin_code')
+            instance.set_password(pin_code)
+        except KeyError:
+            pass
+        # configはOrderedDict
+        if 'config' in validated_data:
+            config = validated_data.get('config')
+            if not isinstance(config, Config):
+                config, _ = Config.objects.update_or_create(course=instance, defaults=config)
+            instance.config = config
+            validated_data.pop('config')
+        for key, val in validated_data.items():
+            setattr(instance, key, val)
+        instance.save(update_fields=validated_data.keys())
+        return instance
 
 
 class CourseWithoutUserSerializer(serializers.ModelSerializer):

--- a/calyx/src/courses/serializers/course_user.py
+++ b/calyx/src/courses/serializers/course_user.py
@@ -42,12 +42,12 @@ class JoinSerializer(PINCodeSerializer):
         """
         課程を受取って，contextからユーザを取得し，POSTされたpin_codeを使って課程に参加する
         """
-        user = self.context.get('user', None)
-        if user is None:
+        request = self.context.get('request', None)
+        if request is None:
             raise AttributeError
         try:
             # 参加に成功すればTrue，失敗すればFalse
-            joined = instance.join(user, validated_data['pin_code'])
+            joined = instance.join(request.user, validated_data['pin_code'])
             if not joined:
                 raise serializers.ValidationError({'pin_code': 'PINコードが正しくありません．'})
         except AlreadyJoinedError:

--- a/calyx/src/courses/tests/base.py
+++ b/calyx/src/courses/tests/base.py
@@ -70,6 +70,13 @@ user_data_set = [
     }
 ]
 
+weak_pin_codes = [
+    # 短すぎる
+    '0',
+    # 単純すぎる
+    '1234'
+]
+
 
 class DatasetMixin(object):
     config_keys = ["show_username", "show_gpa", "rank_limit"]
@@ -85,6 +92,7 @@ class DatasetMixin(object):
         self.default_config = deepcopy(default_config)
         self.lab_data_set = deepcopy(lab_data_set)
         self.config_patterns = self._make_config_patterns()
+        self.weak_pin_codes = deepcopy(weak_pin_codes)
 
     def _make_config_patterns(self):
         patterns = list(product(

--- a/calyx/src/courses/urls.py
+++ b/calyx/src/courses/urls.py
@@ -4,7 +4,7 @@ from rest_framework_nested.routers import NestedDefaultRouter
 
 from .views import (
     CourseViewSet, YearViewSet, JoinAPIView, CourseAdminView,
-    CourseConfigViewSet, LabViewSet, RankViewSet, RequirementStatusView
+    CourseConfigViewSet, LabViewSet, RankViewSet, RequirementStatusView, CoursePINCodeViewSet
 )
 
 router = routers.DefaultRouter()
@@ -17,6 +17,7 @@ course_nested_router.register('join', JoinAPIView, basename='join')
 course_nested_router.register('admins', CourseAdminView, basename='admin')
 course_nested_router.register('config', CourseConfigViewSet, basename='config')
 course_nested_router.register('status', RequirementStatusView, basename='status')
+course_nested_router.register('pin_code', CoursePINCodeViewSet, basename='pin_code')
 course_nested_router.register('labs', LabViewSet, basename='lab')
 course_nested_router.register('ranks', RankViewSet, basename='rank')
 

--- a/calyx/src/courses/views/__init__.py
+++ b/calyx/src/courses/views/__init__.py
@@ -1,4 +1,4 @@
 from .course_user import CourseAdminView, JoinAPIView, RequirementStatusView
-from .courses import CourseViewSet, CourseConfigViewSet, YearViewSet
+from .courses import CourseViewSet, CourseConfigViewSet, YearViewSet, CoursePINCodeViewSet
 from .labs import LabViewSet
 from .ranks import RankViewSet

--- a/calyx/src/courses/views/course_user.py
+++ b/calyx/src/courses/views/course_user.py
@@ -10,7 +10,7 @@ from courses.permissions import (
     IsAdmin, IsCourseMember, IsCourseAdmin
 )
 from courses.serializers import (
-    ReadOnlyCourseSerializer, PINCodeSerializer, UserSerializer, CourseStatusSerializer
+    ReadOnlyCourseSerializer, JoinSerializer, UserSerializer, CourseStatusSerializer
 )
 from .mixins import CourseNestedMixin
 
@@ -27,11 +27,11 @@ class JoinAPIView(CourseNestedMixin, mixins.CreateModelMixin, viewsets.GenericVi
     queryset = Course.objects.prefetch_related(
         Prefetch('users', User.objects.prefetch_related('groups', 'courses').all()),
     ).select_related('admin_user_group', 'year').all()
-    serializer_class = PINCodeSerializer
+    serializer_class = JoinSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     @swagger_auto_schema(
-        request_body=PINCodeSerializer,
+        request_body=JoinSerializer,
         responses={
             200: ReadOnlyCourseSerializer,
             400: "PINコードが正しくない，または既に参加済みです",

--- a/calyx/src/courses/views/course_user.py
+++ b/calyx/src/courses/views/course_user.py
@@ -10,7 +10,7 @@ from courses.permissions import (
     IsAdmin, IsCourseMember, IsCourseAdmin
 )
 from courses.serializers import (
-    CourseSerializer, PINCodeSerializer, UserSerializer, CourseStatusSerializer
+    ReadOnlyCourseSerializer, PINCodeSerializer, UserSerializer, CourseStatusSerializer
 )
 from .mixins import CourseNestedMixin
 
@@ -33,7 +33,7 @@ class JoinAPIView(mixins.CreateModelMixin, viewsets.GenericViewSet):
     @swagger_auto_schema(
         request_body=PINCodeSerializer,
         responses={
-            200: CourseSerializer,
+            200: ReadOnlyCourseSerializer,
             400: "PINコードが正しくない，または既に参加済みです",
             401: "ログインしてください",
             404: "指定された課程は存在しません",
@@ -57,7 +57,7 @@ class JoinAPIView(mixins.CreateModelMixin, viewsets.GenericViewSet):
                 raise serializers.ValidationError({'pin_code': 'PINコードが正しくありません．'})
         except AlreadyJoinedError:
             raise serializers.ValidationError({'non_field_errors': 'このユーザは既に参加しています．'})
-        course_serializer = CourseSerializer(course, context=self.get_serializer_context())
+        course_serializer = ReadOnlyCourseSerializer(course, context=self.get_serializer_context())
         headers = self.get_success_headers(course_serializer.data)
         return Response(course_serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 

--- a/calyx/src/courses/views/course_user.py
+++ b/calyx/src/courses/views/course_user.py
@@ -4,7 +4,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, permissions, mixins, serializers, status, exceptions
 from rest_framework.response import Response
 
-from courses.errors import AlreadyJoinedError, NotJoinedError, NotAdminError
+from courses.errors import NotJoinedError, NotAdminError
 from courses.models import Course
 from courses.permissions import (
     IsAdmin, IsCourseMember, IsCourseAdmin
@@ -17,7 +17,7 @@ from .mixins import CourseNestedMixin
 User = get_user_model()
 
 
-class JoinAPIView(mixins.CreateModelMixin, viewsets.GenericViewSet):
+class JoinAPIView(CourseNestedMixin, mixins.CreateModelMixin, viewsets.GenericViewSet):
     """
     課程に参加するAPIビュー
 
@@ -40,23 +40,11 @@ class JoinAPIView(mixins.CreateModelMixin, viewsets.GenericViewSet):
         }
     )
     def create(self, request, course_pk=None, *args, **kwargs):
-        if not isinstance(course_pk, int):
-            course_pk = int(course_pk)
-        try:
-            course = self.get_queryset().get(pk=course_pk)
-        except Course.DoesNotExist:
-            raise exceptions.NotFound('この課程は存在しません．')
+        course = self.get_course()
         # PINコードをパース
-        pin_code_serializer = self.get_serializer(data=request.data)
+        pin_code_serializer = self.get_serializer(instance=course, data=request.data)
         pin_code_serializer.is_valid(raise_exception=True)
-        pin_code = pin_code_serializer.validated_data['pin_code']
-        try:
-            # 参加に成功すればTrue，失敗すればFalse
-            joined = course.join(request.user, pin_code)
-            if not joined:
-                raise serializers.ValidationError({'pin_code': 'PINコードが正しくありません．'})
-        except AlreadyJoinedError:
-            raise serializers.ValidationError({'non_field_errors': 'このユーザは既に参加しています．'})
+        course = pin_code_serializer.save()
         course_serializer = ReadOnlyCourseSerializer(course, context=self.get_serializer_context())
         headers = self.get_success_headers(course_serializer.data)
         return Response(course_serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/calyx/src/courses/views/courses.py
+++ b/calyx/src/courses/views/courses.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.db.models import Prefetch
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import viewsets, permissions, mixins
+from rest_framework import viewsets, permissions, mixins, status
 from rest_framework.response import Response
 
 from courses.models import Course, Year, Config
@@ -10,14 +10,19 @@ from courses.permissions import (
     IsAdmin, IsCourseMember, IsCourseAdmin, GPARequirement, ScreenNameRequirement
 )
 from courses.serializers import (
-    CourseSerializer, CourseWithoutUserSerializer, YearSerializer, ConfigSerializer
+    ReadOnlyCourseSerializer, CourseUpdateSerializer, CourseCreateSerializer,
+    CourseWithoutUserSerializer, YearSerializer, ConfigSerializer
 )
 from .mixins import CourseNestedMixin
 
 User = get_user_model()
 
 
-class CourseViewSet(viewsets.ModelViewSet):
+class CourseViewSet(mixins.RetrieveModelMixin,
+                    mixins.CreateModelMixin,
+                    mixins.DestroyModelMixin,
+                    mixins.ListModelMixin,
+                    viewsets.GenericViewSet):
     """
     課程のAPIビュー
 
@@ -29,8 +34,6 @@ class CourseViewSet(viewsets.ModelViewSet):
         新しい課程を作成する
     destroy:
         指定した課程を削除する
-    update:
-        指定した課程の情報を更新する
     partial_update:
         指定した課程のパラメータ（全てでなくて良い）を指定して更新する
     """
@@ -38,7 +41,7 @@ class CourseViewSet(viewsets.ModelViewSet):
     queryset = Course.objects.prefetch_related(
         Prefetch('users', User.objects.prefetch_related('groups', 'courses').all()),
     ).select_related('year').all()
-    serializer_class = CourseSerializer
+    serializer_class = ReadOnlyCourseSerializer
 
     def get_permissions(self):
         if self.action == 'list' or self.action == 'create':
@@ -52,12 +55,35 @@ class CourseViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == 'list':
             return CourseWithoutUserSerializer
+        elif self.action == 'retrieve':
+            return ReadOnlyCourseSerializer
+        elif self.action == 'create':
+            return CourseCreateSerializer
+        elif self.action == 'update' or self.action == 'partial_update':
+            return CourseUpdateSerializer
         return super(CourseViewSet, self).get_serializer_class()
+
+    def partial_update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance=instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        instance = serializer.save()
+        resp_serializer = ReadOnlyCourseSerializer(instance, context=self.get_serializer_context())
+        return Response(resp_serializer.data)
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        course = self.perform_create(serializer)
+        resp_serializer = ReadOnlyCourseSerializer(course, context=self.get_serializer_context())
+        headers = self.get_success_headers(resp_serializer.data)
+        return Response(resp_serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
     def perform_create(self, serializer):
         with transaction.atomic():
             course = serializer.save()
             course.register_as_admin(self.request.user)
+        return course
 
 
 class YearViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
fix #150 

## 変更点

- `/couses/<pk>/`
  - PUTでの更新を廃止
  - 年度の変更を不許可に
- `/courses/<pk>/pin_code/`
  - PINコードのエンドポイントを分離

- リクエスト
```python
{"pin_code": "hoge"}
```

- 正常時のレスポンス
  - ステータスコード：200
  - ボディ：なし
- 脆弱なとき

```python
{"pin_code": "このパスワードは短すぎます。最低 4 文字以上必要です。このパスワードは一般的すぎます。"}
```