### PR TITLE
make env出来るようにした

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ $(DB_DIR)/.env.%: guard-env-%
 	cp $(DB_DIR)/.env.sample $(DB_DIR)/.env.${*}
 
 env-%: $(API_SRC_DIR)/src/.env.% $(DB_DIR)/.env.%
+	
 
 env: env-qa env-dev env-prod
 

--- a/Makefile
+++ b/Makefile
@@ -154,10 +154,10 @@ $(API_SRC_DIR)/.env.%: guard-env-%
 $(DB_DIR)/.env.%: guard-env-%
 	cp $(DB_DIR)/.env.sample $(DB_DIR)/.env.${*}
 
-env-%: $(API_SRC_DIR)/.env.% $(DB_DIR)/.env.%
-	
+env-%:
+	make $(API_SRC_DIR)/.env.${*}
+	make $(DB_DIR)/.env.${*}
 
 env: env-qa env-dev env-prod
 
 .PHONY: venv image pull db deps dev dev-clean dev-stop guard-env-% start-% stop-% clean-% manage-% migrate-% prune env-% env update-% ;
-.SECONDARY: ${API_SRC_DIR}/.env.qa ${API_SRC_DIR}/.env.dev ${API_SRC_DIR}/.env.prod

--- a/Makefile
+++ b/Makefile
@@ -148,15 +148,16 @@ manage-%: guard-env-%
 prune:
 	@docker image prune
 
-$(API_SRC_DIR)/src/.env.%: guard-env-%
+$(API_SRC_DIR)/.env.%: guard-env-%
 	cp $(API_SRC_DIR)/.env.sample $(API_SRC_DIR)/.env.${*}
 
 $(DB_DIR)/.env.%: guard-env-%
 	cp $(DB_DIR)/.env.sample $(DB_DIR)/.env.${*}
 
-env-%: $(API_SRC_DIR)/src/.env.% $(DB_DIR)/.env.%
+env-%: $(API_SRC_DIR)/.env.% $(DB_DIR)/.env.%
 	
 
 env: env-qa env-dev env-prod
 
 .PHONY: venv image pull db deps dev dev-clean dev-stop guard-env-% start-% stop-% clean-% manage-% migrate-% prune env-% env update-% ;
+.SECONDARY: ${API_SRC_DIR}/.env.qa ${API_SRC_DIR}/.env.dev ${API_SRC_DIR}/.env.prod


### PR DESCRIPTION
関連Issue #264 

`env: env-qa ...`のように呼んでいたが、`env-%`が依存関係だけあってコマンド行がなかったのでエラーになっていたと思われる

`env-%`にタブだけ足してやると`make env`できた
